### PR TITLE
chore: update opencode to v0.1.194

### DIFF
--- a/pkgs/opencode-sst/default.nix
+++ b/pkgs/opencode-sst/default.nix
@@ -25,11 +25,11 @@
 in
   stdenv.mkDerivation rec {
     pname = "opencode";
-    version = "0.1.146";
+    version = "0.1.194";
 
     src = fetchzip {
       url = "https://github.com/sst/opencode/releases/download/v${version}/opencode-${arch_string stdenv.hostPlatform.system}.zip";
-      hash = "sha256-1HjTDKpZT0JuinxK4qb8aicPKWivQ2qAwn3Dw53K1eY=";
+      hash = "sha256-Z0rMPmm8prlpdJsy5iqBO5BF5VnJ9oUX4+zbT7D1XT8=";
     };
 
     dontBuild = true;  # Pre-compiled binary, no build step needed


### PR DESCRIPTION
Automated update of opencode package from v0.1.146 to v0.1.194.

✅ **Build Status**: Successful  
🔄 **Auto-generated**: This PR was created by the automated update workflow.

**Changes:**
- Updated version from 0.1.146 to 0.1.194
- Updated package hash to sha256-Z0rMPmm8prlpdJsy5iqBO5BF5VnJ9oUX4+zbT7D1XT8=

**Verification:**
- Package builds successfully with Nix
- All dependencies resolved correctly